### PR TITLE
Update Key Level to 3rd level heading markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ v0.1.0:
 Into this:
 
 ```markdown
-### [v0.1.0] - 2016-12-26
+## [v0.1.0] - 2016-12-26
 
-**changes**
+### Changed
 
 - Got stuck in another chimney.
 ```

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ function formatEntry(entry, options) {
   var str = `## [${entry.version}] - ${entry.date}`;
   for (var key in entry) {
     if (entry.hasOwnProperty(key) && key !== 'date' && key !== 'version') {
-      str += `\n\n**${key}**\n\n`;
+      str += `\n\n### ${key}\n\n`;
       str += formatList(entry[key]);
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stringify-changelog",
   "description": "Generate a markdown-formatted changelog from an object, array, yaml or json file.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "homepage": "https://github.com/jonschlinkert/stringify-changelog",
   "author": "Jon Schlinkert (https://github.com/jonschlinkert)",
   "repository": "jonschlinkert/stringify-changelog",
@@ -22,14 +22,14 @@
     "test": "mocha"
   },
   "dependencies": {
-    "extend-shallow": "^2.0.1",
-    "isobject": "^2.1.0",
+    "extend-shallow": "^3.0.2",
+    "isobject": "^4.0.0",
     "js-yaml-lite": "^0.1.1",
-    "moment": "^2.14.1"
+    "moment": "^2.29.1"
   },
   "devDependencies": {
-    "gulp-format-md": "^0.1.9",
-    "mocha": "^2.5.3"
+    "gulp-format-md": "^2.0.0",
+    "mocha": "^9.2.2"
   },
   "keywords": [
     "changelog",

--- a/test.js
+++ b/test.js
@@ -18,13 +18,13 @@ describe('changelog', function() {
     assert.equal(changelog('fixtures/a.yaml'), [
       '## [v0.2.0] - 2016-12-26',
       '',
-      '**changes**',
+      '### changes',
       '',
       '- Got stuck in another chimney.',
       '',
       '## [v0.1.0] - 2015-12-26',
       '',
-      '**changes**',
+      '### changes',
       '',
       '- Got stuck in a chimney last night.',
       ''
@@ -35,13 +35,13 @@ describe('changelog', function() {
     assert.equal(changelog('fixtures/a.yaml', {repo: 'foo/bar'}), [
       '## [v0.2.0] - 2016-12-26',
       '',
-      '**changes**',
+      '### changes',
       '',
       '- Got stuck in another chimney.',
       '',
       '## [v0.1.0] - 2015-12-26',
       '',
-      '**changes**',
+      '### changes',
       '',
       '- Got stuck in a chimney last night.',
       '',
@@ -53,13 +53,13 @@ describe('changelog', function() {
     assert.equal(changelog('fixtures/a.yaml', {owner: 'foo', name: 'bar'}), [
       '## [v0.2.0] - 2016-12-26',
       '',
-      '**changes**',
+      '### changes',
       '',
       '- Got stuck in another chimney.',
       '',
       '## [v0.1.0] - 2015-12-26',
       '',
-      '**changes**',
+      '### changes',
       '',
       '- Got stuck in a chimney last night.',
       '',
@@ -71,7 +71,7 @@ describe('changelog', function() {
     assert.equal(changelog('fixtures/a.yml'), [
       '## [v0.1.0] - 2015-12-26',
       '',
-      '**changes**',
+      '### changes',
       '',
       '- Got stuck in a chimney last night.',
       ''
@@ -82,7 +82,7 @@ describe('changelog', function() {
     assert.equal(changelog(path.resolve(__dirname, 'fixtures/changelog')), [
       '## [v0.2.0] - 2016-12-26',
       '',
-      '**changes**',
+      '### changes',
       '',
       '- Got stuck in another chimney.',
       ''
@@ -94,7 +94,7 @@ describe('changelog', function() {
     assert.equal(changelog(data), [
       '## [v0.2.0] - 2016-12-26',
       '',
-      '**changes**',
+      '### changes',
       '',
       '- Got stuck in another chimney.',
       ''
@@ -109,7 +109,7 @@ describe('changelog', function() {
     assert.equal(changelog(data), [
       '## [v0.2.0] - 2016-12-26',
       '',
-      '**changes**',
+      '### changes',
       '',
       '- Got stuck in another chimney.',
       ''
@@ -129,7 +129,7 @@ describe('changelog', function() {
     assert.equal(changelog(data, opts), [
       '## [v0.2.0] - 2016-12-26',
       '',
-      '**changes**',
+      '### changes',
       '',
       '- Got stuck in another chimney.',
       ''
@@ -152,13 +152,13 @@ describe('changelog', function() {
       '',
       '## [v0.2.0] - 2016-12-26',
       '',
-      '**changes**',
+      '### changes',
       '',
       '- Got stuck in another chimney.',
       '',
       '## [v0.1.0] - 2015-12-26',
       '',
-      '**changes**',
+      '### changes',
       '',
       '- Got stuck in a chimney last night.',
       '',


### PR DESCRIPTION
First, I'd like to say this is a helpful module.  Genuinely nice when you need change logs in multiple formats (for machine consumption and human readable).  I'm not sure if you are still maintaining it. It hasn't been updated in a while.

I noticed one difference from the output and the suggested formatting of https://keepachangelog.com/en/1.0.0/ - The key level/types of changes. In Keep a Change Log, they show this level as a third level heading in Markdown
![image](https://user-images.githubusercontent.com/12159356/160884079-fdc2774e-7b07-4950-9f85-57bc354a19aa.png)

But this module formats that entity as bold text (**changes**).  It's a relatively minor difference but it does produce Markdown Lint warnings - MD036
![image](https://user-images.githubusercontent.com/12159356/160884801-80daa83d-2d6d-428a-b3cf-c38d77303ba7.png)
https://github.com/updownpress/markdown-lint/blob/master/rules/036-no-emphasis-as-header.md

This pull request contains an update to switch to third level headings.  While in there I updated major dependencies and ran through the tests. 

Thanks again for sharing this module!